### PR TITLE
Temporary workaround for C++ SDK Crash.

### DIFF
--- a/GoogleUtilities/Logger/GULLogger.m
+++ b/GoogleUtilities/Logger/GULLogger.m
@@ -90,11 +90,14 @@ void GULLoggerEnableSTDERR(void) {
 }
 
 void GULLoggerForceDebug(void) {
+#warning Return instead of doing anything to avoid the App Store check.
+  return;
+
   // We should enable debug mode if we're not running from App Store.
-  if (![GULAppEnvironmentUtil isFromAppStore]) {
-    sGULLoggerDebugMode = YES;
-    GULSetLoggerLevel(GULLoggerLevelDebug);
-  }
+  //  if (![GULAppEnvironmentUtil isFromAppStore]) {
+  //    sGULLoggerDebugMode = YES;
+  //    GULSetLoggerLevel(GULLoggerLevelDebug);
+  //  }
 }
 
 __attribute__((no_sanitize("thread"))) void GULSetLoggerLevel(GULLoggerLevel loggerLevel) {
@@ -104,8 +107,10 @@ __attribute__((no_sanitize("thread"))) void GULSetLoggerLevel(GULLoggerLevel log
     return;
   }
   GULLoggerInitializeASL();
+#warning Ensure nothing below Notice is set to avoid the App Store check.
   // We should not raise the logger level if we are running from App Store.
-  if (loggerLevel >= GULLoggerLevelNotice && [GULAppEnvironmentUtil isFromAppStore]) {
+  //  if (loggerLevel >= GULLoggerLevelNotice && [GULAppEnvironmentUtil isFromAppStore]) {
+  if (loggerLevel >= GULLoggerLevelNotice) {
     return;
   }
 


### PR DESCRIPTION
Cherrypicked from https://github.com/google/GoogleUtilities/pull/69/files

This branch is based off 6.7.1 which is the same as 6.7.2 (that release was reverted). CoS was implicitly depending on 6.7.2.
